### PR TITLE
Keep imagebitmap immutable

### DIFF
--- a/index.html
+++ b/index.html
@@ -636,7 +636,7 @@
             <dl class="parameters">
               <dt>optional sequence&lt;ImageFormat&gt; possibleFormats</dt>
               <dd>
-                <p>A list of image formats that users can handler.</p>
+                A list of image formats that users can handler.
               </dd>
             </dl>
           </dd>
@@ -660,7 +660,7 @@
             <dl class="parameters">
               <dt>ImageFormat format</dt>
               <dd>
-                <p>The format that users want.</p>
+                The format that users want.
               </dd>
             </dl>
           </dd>
@@ -692,67 +692,21 @@
             <dl class="parameters">
               <dt>ImageFormat format</dt>
               <dd>
-                <p>The format that users want.</p>
+                The format that users want.
               </dd>
               <dt>ArrayBuffer buffer</dt>
               <dd>
-                <p>A container for receiving the mapped image data.</p>
+                A container for receiving the mapped image data.
               </dd>
               <dt>long offset</dt>
               <dd>
-                <p>
-                  The beginning position of the <code>buffer</code> to place
-                  the mapped data.
-                </p>
+                The beginning position of the <code>buffer</code> to place
+                the mapped data.
               </dd>
               <dt>long length</dt>
               <dd>
-                <p>
-                  The length of space in the <code>buffer</code> that could be
-                  filled.
-                </p>
-              </dd>
-            </dl>
-          </dd>
-
-          <dt>
-            [Throws]
-            boolean setDataFrom()
-          </dt>
-          <dd>
-            <p>
-              Set an external image data into a <code>ImageBitmap</code>.
-            </p>
-            <dl class="parameters">
-              <dt>ImageFormat format</dt>
-              <dd>
-                <p>The format of the external image data.</p>
-              </dd>
-              <dt>ArrayBuffer buffer</dt>
-              <dd>
-                <p>A container of the external image data.</p>
-              </dd>
-              <dt>long offset</dt>
-              <dd>
-                <p>
-                  The beginning position of the <code>buffer</code> where the
-                  external image data is placed.
-                </p>
-              </dd>
-              <dt>long length</dt>
-              <dd>
-                <p>
-                  The length of spaces in the <code>buffer</code> that the
-                  external image data is palced.
-                </p>
-              </dd>
-              <dt>ImageFormatPixelLayout layout</dt>
-              <dd>
-                <p>
-                  The pixel layout of the external image data, which describes
-                  how the data is arranged in the given <code>buffer</code> as
-                  the given <code>format</code>.
-                </p>
+                The length of space in the <code>buffer</code> that could be
+                filled.
               </dd>
             </dl>
           </dd>

--- a/index.html
+++ b/index.html
@@ -77,13 +77,14 @@
   <body>
     <section id='abstract'>
       <p>
-        This specification extends the <a><code>ImageBitmap interface</code></a>
-        to allow JavaScript developers to read the underlying data out and set
-        an external data into an <a><code>ImageBitmap</code></a> in a set of
-        supported <a>ImageFormat</a>s.
-      </p>
-      <p>
-
+        This specification extends the <a>ImageBitmap</a> interface
+        to allow JavaScript developers to read the underlying data from an
+        <a>ImageBitmap</a> object into a given
+        <a>BufferSource</a> object in a set of supported <a>ImageFormat</a>s.
+        Also, this specification extends the
+        <a>ImageBitmapFactories</a> interface to allow JavaScript
+        developers to create an <a>ImageBitmap</a> object from a given
+        <a>BufferSource</a> object.
       </p>
     </section>
 
@@ -101,28 +102,34 @@
     <section>
       <h2>Introduction</h2>
       <p>
-        The <a><code>ImageBitmap interface</code></a> is originally designed as
+        The <a>ImageBitmap</a> interface is originally designed as
         a pure opaque handler to an image data buffer inside a browser so that
-        how it stores the buffer is uknown to users and optimized to platforms.
+        how the browser stores the buffer is uknown to users and optimized to
+        platforms.
       </p>
       <p>
-        Currently, the <em>Media Capture Stream with Video Worker</em>
+        Recently, the <em>Media Capture Stream with Video Worker</em>
         specification [<a>mediacapture-worker</a>] proposes a video processing
         framework on the web platform. It provides web applications a way to
-        hook a processing script (which is ran in a <a>VideoWorker</a>) to a
+        hook a processing script (which is ran in a <code>WebWorker</code>) to a
         <code>MediaStreamTrack</code> with video data so that each frame will
-        be processed accordingly. If a <a>VideoWorker</a> is successfully hooked
-        to a track, then for each video frame of the track, the framework will
-        post a <a>VideoProcessEvent</a> to the <a>VideoWorker</a>.
+        be processed accordingly. If a <code>WebWorker</code> is successfully hooked
+        to a track, then, for each video frame of the track, the framework posts
+        a <a>VideoProcessEvent</a> to the <code>WebWorker</code>.
         A <a>VideoProcessEvent</a> has an <code>inputImageBitmap</code>
         property and an <code>outputImageBitmap</code> property so that
-        JavaScript developers could read the raw image data of the current video
-        frame out from the <code>inputImageBitmap</code>, then after some
-        processing, write the processed image data back into the
-        <code>outputImageBitmap</code> which is handled by the framework thereafter.
-        This specification is meant to extend the <a>ImageBitmap interface</a>
-        with new APIs to read data from and write data back into an
-        <code>ImageBitmap</code>.
+        JavaScript developers can read the raw image data of the current video
+        frame out from the <code>inputImageBitmap</code> into a given
+        <a>BufferSource</a> object, then after some processing, create a new
+        <a>ImageBitmap</a> object from the processed <a>BufferSource</a> object
+        and assigned the newly created <a>ImageBitmap</a> object to the
+        <code>outputImageBitmap</code> property which is handled by the framework
+        thereafter. So, for supporting the <em>Media Capture Stream with Video
+        Worker</em>, this specification is meant to extend the <a>ImageBitmap</a>
+        interface with new APIs to read data from an
+        <a>ImageBitmap</a> object into a given <a>BufferSource</a> object and
+        extent the <a>ImageBitmapFactories</a> interface to create an
+        <a>ImageBitmap</a> object from a given <a>BufferSource</a> object.
       </p>
       <p>
         The <em>Media Capture Stream with Video Worker</em> specification
@@ -145,19 +152,21 @@
           </li>
           <li>
             If developers use JavaScript(/asm.js) to process the frames, then
-            new APIs to access the raw data inside an ImageBitmp are needed
-            since the current <a><code>ImageBitmap interface</code></a> provides
+            new APIs to access the raw data inside an <a>ImageBitmap</a> object are needed
+            since the current <a>ImageBitmap</a> interface provides
             no way for developers to do so.
           </li>
         </ol>
       </p>
       <p>
-        In this specification, the original <a>ImageBitmap interface</a> is extended
-        with four methods to let developers read data from and write data into an
-        <a>ImageBitmap</a> in a set of supported <a>ImageFormat</a>s.
-        Also, two interfaces <a>ImageFormatPixelLayout</a> and <a>ChannelPixelLayout</a>
+        In this specification, the original <a>ImageBitmap</a> interface is extended
+        with three methods to let developers read data from an
+        <a>ImageBitmap</a> object in a set of supported <a>ImageFormat</a>s and
+        two interfaces <a>ImageFormatPixelLayout</a> and <a>ChannelPixelLayout</a>
         are proposed to work with the extend <a>ImageBitmap</a> methods to describe
-        how the accessed image data is arranged in memory.
+        how the accessed image data is arranged in memory. Also, the <a>ImageBitmapFactories</a>
+        interface is extended to let developers create <a>ImageBitmap</a> from
+        a given <a>BufferSource</a>.
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -167,9 +167,12 @@
       </h2>
       <p>
         The <code><a href=
-        "http://www.w3.org/TR/html51/webappapis.html#images">
-        <dfn>ImageBitmap interface</dfn></a></code> this specification extends
-        are defined in [[!HTML51]].
+        "http://www.w3.org/TR/html51/webappapis.html#imagebitmap">
+        <dfn>ImageBitmap</dfn></a></code> interface
+        and <code><a href=
+        "http://www.w3.org/TR/html51/webappapis.html#imagebitmapfactories">
+        <dfn>ImageBitmapFactories</dfn></a></code> interface this specification
+        extends are defined in [[!HTML51]].
       </p>
       <p>
         The <em>Media Capture Stream with Video Worker</em> specificaton proposes a video
@@ -179,13 +182,13 @@
       </p>
       <p>
         The <code><a href=
-        "http://chiahungtai.github.io/mediacapture-worker/#videoworker-interface">
-        <dfn>VideoWorker</dfn></a></code> is defined in [<a>mediacapture-worker</a>].
+        "http://chiahungtai.github.io/mediacapture-worker/#videoprocessevent-interface">
+        <dfn>VideoProcessEvent</dfn></a></code> is defined in [<a>mediacapture-worker</a>].
       </p>
       <p>
         The <code><a href=
-        "http://chiahungtai.github.io/mediacapture-worker/#videoprocessevent-interface">
-        <dfn>VideoProcessEvent</dfn></a></code> is defined in [<a>mediacapture-worker</a>].
+        "http://www.w3.org/TR/WebIDL-1/#common-BufferSource">
+        <dfn>BufferSource</dfn></a></code> is defined in [[!WebIDL]]
       </p>
     </section>
 
@@ -484,7 +487,7 @@
             <dd>
               <p>
                 The beginning position of this channel's data (relative to the given
-                ArrayBuffer parameter of the mapDataInto() method.)
+                BufferSource parameter of the mapDataInto() method.)
               </p>
             </dd>
 
@@ -694,7 +697,7 @@
               <dd>
                 The format that users want.
               </dd>
-              <dt>ArrayBuffer buffer</dt>
+              <dt>BufferSource buffer</dt>
               <dd>
                 A container for receiving the mapped image data.
               </dd>
@@ -711,6 +714,119 @@
             </dl>
           </dd>
         </dl>
+      </section>
+
+      <section>
+        <h2>ImageBitmapFactories extensions</h2>
+        <dl class="idl" title="[NoInterfaceObject, Exposed=(Window,Worker)] partial interface ImageBitmapFactories">
+          <dt>
+            Promise&lt;ImageBitmap&gt;  createImageBitmap()
+          </dt>
+          <dd>
+            <p>
+              Create an <code>ImageBitmap</code> from a <code>BufferSource</code> containg raw image data.
+            </p>
+            <dl class="parameters">
+              <dt>BufferSource buffer</dt>
+              <dd>
+                A container of the raw image data.
+              </dd>
+              <dt>long offset</dt>
+              <dd>
+                The beginning position of the <code>buffer</code> where the raw image data is placed.
+              </dd>
+              <dt>long length</dt>
+              <dd>
+                The length of spaces in the <code>buffer</code> that the raw image data is palced.
+              </dd>
+              <dt>ImageFormat format</dt>
+              <dd>
+                The format of the raw image data.
+              </dd>
+              <dt>ImageFormatPixelLayout layout</dt>
+              <dd>
+                The pixel layout of the raw image data,
+                which describes how the data is arranged in the given <code>buffer</code> as the given <code>format</code>.
+              </dd>
+            </dl>
+          </dd>
+
+          <dt>
+            Promise&lt;ImageBitmap&gt;  createImageBitmap()
+          </dt>
+          <dd>
+            <p>
+              Create an <code>ImageBitmap</code> from a <code>BufferSource</code> containg raw image data with a given cropping area.
+            </p>
+            <dl class="parameters">
+              <dt>BufferSource buffer</dt>
+              <dd>
+                A container of the raw image data.
+              </dd>
+              <dt>long offset</dt>
+              <dd>
+                The beginning position of the <code>buffer</code> where the raw image data is placed.
+              </dd>
+              <dt>long length</dt>
+              <dd>
+                The length of spaces in the <code>buffer</code> that the raw image data is palced.
+              </dd>
+              <dt>ImageFormat format</dt>
+              <dd>
+                The format of the raw image data.
+              </dd>
+              <dt>ImageFormatPixelLayout layout</dt>
+              <dd>
+                The pixel layout of the raw image data,
+                which describes how the data is arranged in the given <code>buffer</code> as the given <code>format</code>.
+              </dd>
+              <dt>long sx</dt>
+              <dd>
+                The x-coordinate of the starting point of the cropping rectangle.
+              </dd>
+              <dt>long sy</dt>
+              <dd>
+                The y-coordinate of the starting point of the cropping rectangle.
+              </dd>
+              <dt>long sw</dt>
+              <dd>
+                The width of the cropping rectangle.
+              </dd>
+              <dt>long sh</dt>
+              <dd>
+                The height of the cropping rectangle.
+              </dd>
+            </dl>
+          </dd>
+        </dl>
+
+        <p>
+          When the <code>createImageBitmap()</code> is invocked, the User Agent MUST run the following steps:
+          <ol>
+            <li>
+              If either the <em>sw</em> or <em>sh</em> arguments are specified but zero,
+              return a promise rejected with an IndexSizeError exception and abort these steps.
+            </li>
+            <li>
+              If the <em>buffer</em> has been <code><a href="http://www.w3.org/TR/html51/infrastructure.html#concept-transferable-neutered">neutered</a></code>,
+              return a promise rejected with an InvalidStateError exception and abort these steps.
+            </li>
+            <li>
+              Create a new <code>ImageBitmap</code> object.
+            </li>
+            <li>
+              Let the <code>ImageBitmap</code> object's bitmap data be the image data given by the <code>BufferSource</code> object,
+              <code><a href="http://www.w3.org/TR/html51/webappapis.html#cropped-to-the-source-rectangle">cropped to the source rectangle</a></code>.
+            </li>
+            <li>
+              Return a new <code>Promise</code>, but continue running these steps <code><a href="http://www.w3.org/TR/html51/infrastructure.html#in-parallel">in parallel</a></code>.
+            </li>
+            <li>
+              <code><a href="http://www.w3.org/TR/html51/infrastructure.html#concept-resolver-fulfill">Resolve</a></code> the <code>Promise</code> with the new <code>ImageBitmap</code> object as the value.
+            </li>
+          <ol>
+
+        </p>
       </section>
 
     </section>


### PR DESCRIPTION
Address the issue #5.

I remove the "setDataFrom()" method from the ImageBitmap interface and then add new "createImageBitmap()" methods into the ImageBitmapFactories interface.

@rocallahan and @ChiahungTai, please review this PR, thanks!
